### PR TITLE
Change --save-dev to --save in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We welcome all kinds of contributions! The most basic way to show your support i
 From the same directory as your project's [Gruntfile][Getting Started] and [package.json][], install this plugin with the following command:
 
 ```bash
-npm install permalinks --save-dev
+npm install permalinks --save
 ```
 
 Once that's done, just add `permalinks`, the name of this module, to the `plugins` option in the Assemble task:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 From the same directory as your project's [Gruntfile][Getting Started] and [package.json][], install this plugin with the following command:
 
 ```bash
-npm install {%= name %} --save-dev
+npm install {%= name %} --save
 ```
 
 Once that's done, just add `permalinks`, the name of this module, to the `plugins` option in the Assemble task:


### PR DESCRIPTION
Assemble plugins are looked up in `dependencies` of `package.json`, not
in `devDependencies`. So user of plugins should install them as that.

Following current instructions and using `--save-dev` leads to plugin
not working, because it's not called.
