### PR TITLE
Option to use filename as replacement

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,8 @@ module.exports = function(grunt) {
       options: {
         plugins: ['./permalinks.js'],
         helpers: ['test/fixtures/helpers/*.js'],
-        layout: 'test/fixtures/default.hbs',
+        layoutdir: 'test/fixtures',
+        layout: 'default.hbs',
         data: 'test/fixtures/ipsum.json',
         assets: 'test/assets'
       },
@@ -277,6 +278,32 @@ module.exports = function(grunt) {
         },
         files: [
           {expand: true, cwd: 'test/fixtures/pages', src: ['**/*.hbs'], dest: 'test/actual/replacement_pattern/', ext: '.html'}
+        ]
+      },
+      // Should modify dest path using a filename replacement date with preset
+      filename_replacement_preset: {
+        options: {
+          engine: 'handlebars',
+          permalinks: {
+            preset: 'pretty',
+            filename: true
+          }
+        },
+        files: [
+          {expand: true, cwd: 'test/fixtures/posts', src: ['**/*.md'], dest: 'test/actual/filename_replacement_preset/', ext: '.html'}
+        ]
+      },
+      // Should modify dest path using a filename replacement date with structure
+      filename_replacement_structure: {
+        options: {
+          engine: 'handlebars',
+          permalinks: {
+            structure: ':category/:basename/index:ext',
+            filename: true
+          }
+        },
+        files: [
+          {expand: true, cwd: 'test/fixtures/posts', src: ['**/*.md'], dest: 'test/actual/filename_replacement_structure/', ext: '.html'}
         ]
       },
       // Should generate a javascript file with all non-function replacement patterns

--- a/permalinks.js
+++ b/permalinks.js
@@ -98,18 +98,6 @@ module.exports = function(params, callback) {
       }
 
       /**
-       * Strip date from pages 
-       * Works well with `:date` pattern
-       * @examples
-       *   2014-02-10-foo.html => foo.html
-       */
-      if(options.stripdate === true) {
-        page.basename = page.basename.replace(/^(\d+)-(\d+)-(\d+)-?/, '', function (y, m, d) {
-          return [y,m,d].join('/');
-        });
-      }
-
-      /**
        * Strip date from filename
        * And modify `basename` and `slug` property
        * If no yfm for `date`, make date replacement avalaible as page.data.date context

--- a/permalinks.js
+++ b/permalinks.js
@@ -97,6 +97,37 @@ module.exports = function(params, callback) {
         page.basename = page.basename.replace(/^\d+\-?/, '');
       }
 
+      /**
+       * Strip date from pages 
+       * Works well with `:date` pattern
+       * @examples
+       *   2014-02-10-foo.html => foo.html
+       */
+      if(options.stripdate === true) {
+        page.basename = page.basename.replace(/^(\d+)-(\d+)-(\d+)-?/, '', function (y, m, d) {
+          return [y,m,d].join('/');
+        });
+      }
+
+      /**
+       * Strip date from filename
+       * And modify `basename` and `slug` property
+       * If no yfm for `date`, make date replacement avalaible as page.data.date context
+       * @examples
+       *   2014-02-10-foo.html => foo.html
+       *   {
+       *     basename: foo,
+       *     slug: foo
+       *   },
+       *   data: { date: date object(2014-02-10) }
+       */
+      if(options.filename === true) {
+        page.basename = page.slug = page.basename.replace(/^(\d+)-(\d+)-(\d+)-?/, function (a, y, m, d) {
+          page.data.date = (page.data.date) ? page.data.date : new Date([y,m,d].join('-'));
+          return [].join('/');
+        });
+      }
+
 
       // Best guesses at some useful patterns
       var specialPatterns = {

--- a/test/actual/filename_replacement_preset/bar/index.html
+++ b/test/actual/filename_replacement_preset/bar/index.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Bar</title>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../../assets/validation.css">
+  </head>
+  <body>
+    <div class="container">
+      <section id="validate"></section>
+
+      <hr>
+      <!-- pagination -->
+      <h4>pagination</h4>
+      <ul class="pagination pagination-lg">
+
+  
+
+  
+    <li class="prev">
+      <a href="../foo/index.html">&laquo;</a>
+    </li>
+    <li class="prev">
+      <a href="../new-year/index.html">&lsaquo;</a>
+    </li>
+  
+
+  
+    <li>
+      <a href="../foo/index.html">1</a>
+    </li>
+  
+    <li>
+      <a href="../last-year/index.html">2</a>
+    </li>
+  
+    <li>
+      <a href="../new-year/index.html">3</a>
+    </li>
+  
+    <li class="active">
+      <a href="index.html">4</a>
+    </li>
+  
+
+  
+
+  
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">&rsaquo;</a>
+    </li>
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">&raquo;</a>
+    </li>
+  
+
+</ul>
+      <hr>
+      <h4>pagination-justified</h4>
+      <ul class="pagination pagination-lg justified">
+
+  
+
+  
+    <li class="prev">
+      <a href="../foo/index.html">&laquo;</a>
+    </li>
+    <li class="prev">
+      <a href="../new-year/index.html">&lsaquo;</a>
+    </li>
+  
+
+  
+    <li>
+      <a href="../foo/index.html">1</a>
+    </li>
+  
+    <li>
+      <a href="../last-year/index.html">2</a>
+    </li>
+  
+    <li>
+      <a href="../new-year/index.html">3</a>
+    </li>
+  
+    <li class="active">
+      <a href="index.html">4</a>
+    </li>
+  
+
+  
+
+  
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">&rsaquo;</a>
+    </li>
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">&raquo;</a>
+    </li>
+  
+
+</ul>
+      <hr>
+      <!-- paginate -->
+      <h4>paginate</h4>
+      <ul class="pager">
+
+  
+
+  
+    <li class="previous">
+      <a href="../foo/index.html">&larr; Prev</a>
+    </li>
+  
+
+  
+    <li>
+      <a href="../foo/index.html">1</a>
+    </li>
+  
+    <li>
+      <a href="../last-year/index.html">2</a>
+    </li>
+  
+    <li>
+      <a href="../new-year/index.html">3</a>
+    </li>
+  
+    <li class="active">
+      <a href="index.html">4</a>
+    </li>
+  
+
+  
+
+  
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Next &rarr;</a>
+    </li>
+  
+
+</ul><style>
+.unselectable {
+  -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+}
+</style>
+      <hr>
+
+
+      <div class="row">
+        <div class="col-md-3">
+          <div class="bs-sidebar hidden-print" role="complementary">
+            <!-- navigation -->
+            <div class="list-group">
+  
+  <a href="../foo/index.html" class="list-group-item">
+    foo
+  </a>
+  
+  <a href="../last-year/index.html" class="list-group-item">
+    last-year
+  </a>
+  
+  <a href="../new-year/index.html" class="list-group-item">
+    new-year
+  </a>
+  
+  <a href="index.html" class="list-group-item active">
+    bar
+  </a>
+  
+</div>
+            <hr>
+
+
+            <!-- pagination -->
+            <ul class="nav nav-pills nav-stacked">
+
+  
+
+  
+    <li class="prev">
+      <a href="../foo/index.html">First</a>
+    </li>
+    <li class="prev">
+      <a href="../new-year/index.html">&larr; Previous</a>
+    </li>
+  
+
+  
+    <li>
+      <a href="../foo/index.html">1</a>
+    </li>
+  
+    <li>
+      <a href="../last-year/index.html">2</a>
+    </li>
+  
+    <li>
+      <a href="../new-year/index.html">3</a>
+    </li>
+  
+    <li class="active">
+      <a href="index.html">4</a>
+    </li>
+  
+
+  
+
+  
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Next &rarr;</a>
+    </li>
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Last</a>
+    </li>
+  
+
+</ul>
+            <hr>
+
+
+            <!-- Summaries -->
+            <h4>Sanity Check</h4>
+            <ul class="list-group">
+              <li class="list-group-item">
+                <span class="badge">0</span>
+                Total Categories
+              </li>
+              <li class="list-group-item">
+                <span class="badge">8</span>
+                Total Tags
+              </li>
+            </ul>
+
+          </div>
+        </div>
+        <div class="col-md-9" role="main">
+          <div class="row">
+            <div class="col-md-4">
+
+              <!-- Pages -->
+              <div class="docs-section">
+                <div class="docs-header" id="content">
+                  <h4>{{relative}} helper</h4>
+                  <strong>Page title: Bar</strong>
+                </div>
+                <ul class="nav nav-pills nav-stacked">
+                
+                  <li>
+                    <a href="../foo/index.html">Foo</a>
+                  </li>
+                
+                  <li>
+                    <a href="../last-year/index.html">Last Year</a>
+                  </li>
+                
+                  <li>
+                    <a href="../new-year/index.html">New Year</a>
+                  </li>
+                
+                  <li class="active">
+                    <a href="index.html">Bar</a>
+                  </li>
+                
+                </ul>
+              </div>
+              <hr>
+
+
+              <!-- Pages -->
+              <div class="docs-section">
+                <div class="docs-header" id="content">
+                  <h4>{{rel}} helper</h4>
+                  <strong>Page title: Bar</strong>
+                </div>
+                <ul class="nav nav-pills nav-stacked">
+                
+                  <li>
+                    <a href="../foo/index.html">Foo</a>
+                  </li>
+                
+                  <li>
+                    <a href="../last-year/index.html">Last Year</a>
+                  </li>
+                
+                  <li>
+                    <a href="../new-year/index.html">New Year</a>
+                  </li>
+                
+                  <li class="active">
+                    <a href="index.html">Bar</a>
+                  </li>
+                
+                </ul>
+              </div>
+            </div>
+            <div class="col-md-4">
+
+              <!-- Tags Collection -->
+              <div class="panel panel-default">
+                <div class="panel-heading">Tags</div>
+                <div class="panel-body">
+                
+                  <div>Related pages for: <span class="label label-warning">advanced</span></div>
+                  <ul>
+                  
+                    <li class="active">
+                      <a href="index.html">Bar</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">android</span></div>
+                  <ul>
+                  
+                    <li class="active">
+                      <a href="index.html">Bar</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">assemble</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../foo/index.html">Foo</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../last-year/index.html">Last Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">beginner</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../foo/index.html">Foo</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../last-year/index.html">Last Year</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../new-year/index.html">New Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">intro</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../foo/index.html">Foo</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">javascript</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../last-year/index.html">Last Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">php</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../new-year/index.html">New Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">tutorial</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../foo/index.html">Foo</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../last-year/index.html">Last Year</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../new-year/index.html">New Year</a>
+                    </li>
+                  
+                    <li class="active">
+                      <a href="index.html">Bar</a>
+                    </li>
+                  
+                  </ul>
+                
+                </div>
+              </div>
+            </div>
+            <div class="col-md-4">
+
+              <!-- Categories Collection -->
+              <div class="panel panel-default">
+                <div class="panel-heading">Categories</div>
+                <div class="panel-body">
+                
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Content -->
+          
+<h1 id="header">Header</h1>
+<blockquote>
+<p>Cras sit amet nibh libero, in gravida nulla.</p>
+</blockquote>
+
+
+          <hr>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/test/actual/filename_replacement_preset/foo/index.html
+++ b/test/actual/filename_replacement_preset/foo/index.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Foo</title>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../../assets/validation.css">
+  </head>
+  <body>
+    <div class="container">
+      <section id="validate"></section>
+
+      <hr>
+      <!-- pagination -->
+      <h4>pagination</h4>
+      <ul class="pagination pagination-lg">
+
+  
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">&laquo;</a>
+    </li>
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">&lsaquo;</a>
+    </li>
+  
+
+  
+
+  
+    <li class="active">
+      <a href="index.html">1</a>
+    </li>
+  
+    <li>
+      <a href="../last-year/index.html">2</a>
+    </li>
+  
+    <li>
+      <a href="../new-year/index.html">3</a>
+    </li>
+  
+    <li>
+      <a href="../bar/index.html">4</a>
+    </li>
+  
+
+  
+    <li class="next">
+      <a href="../last-year/index.html">&rsaquo;</a>
+    </li>
+    <li class="next">
+      <a href="../bar/index.html">&raquo;</a>
+    </li>
+  
+
+  
+
+</ul>
+      <hr>
+      <h4>pagination-justified</h4>
+      <ul class="pagination pagination-lg justified">
+
+  
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">&laquo;</a>
+    </li>
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">&lsaquo;</a>
+    </li>
+  
+
+  
+
+  
+    <li class="active">
+      <a href="index.html">1</a>
+    </li>
+  
+    <li>
+      <a href="../last-year/index.html">2</a>
+    </li>
+  
+    <li>
+      <a href="../new-year/index.html">3</a>
+    </li>
+  
+    <li>
+      <a href="../bar/index.html">4</a>
+    </li>
+  
+
+  
+    <li class="next">
+      <a href="../last-year/index.html">&rsaquo;</a>
+    </li>
+    <li class="next">
+      <a href="../bar/index.html">&raquo;</a>
+    </li>
+  
+
+  
+
+</ul>
+      <hr>
+      <!-- paginate -->
+      <h4>paginate</h4>
+      <ul class="pager">
+
+  
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">&larr; Prev</a>
+    </li>
+  
+
+  
+
+  
+    <li class="active">
+      <a href="index.html">1</a>
+    </li>
+  
+    <li>
+      <a href="../last-year/index.html">2</a>
+    </li>
+  
+    <li>
+      <a href="../new-year/index.html">3</a>
+    </li>
+  
+    <li>
+      <a href="../bar/index.html">4</a>
+    </li>
+  
+
+  
+    <li class="next">
+      <a href="../bar/index.html">Next &rarr;</a>
+    </li>
+  
+
+  
+
+</ul><style>
+.unselectable {
+  -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+}
+</style>
+      <hr>
+
+
+      <div class="row">
+        <div class="col-md-3">
+          <div class="bs-sidebar hidden-print" role="complementary">
+            <!-- navigation -->
+            <div class="list-group">
+  
+  <a href="index.html" class="list-group-item active">
+    foo
+  </a>
+  
+  <a href="../last-year/index.html" class="list-group-item">
+    last-year
+  </a>
+  
+  <a href="../new-year/index.html" class="list-group-item">
+    new-year
+  </a>
+  
+  <a href="../bar/index.html" class="list-group-item">
+    bar
+  </a>
+  
+</div>
+            <hr>
+
+
+            <!-- pagination -->
+            <ul class="nav nav-pills nav-stacked">
+
+  
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
+  
+
+  
+
+  
+    <li class="active">
+      <a href="index.html">1</a>
+    </li>
+  
+    <li>
+      <a href="../last-year/index.html">2</a>
+    </li>
+  
+    <li>
+      <a href="../new-year/index.html">3</a>
+    </li>
+  
+    <li>
+      <a href="../bar/index.html">4</a>
+    </li>
+  
+
+  
+    <li class="next">
+      <a href="../last-year/index.html">Next &rarr;</a>
+    </li>
+    <li class="next">
+      <a href="../bar/index.html">Last</a>
+    </li>
+  
+
+  
+
+</ul>
+            <hr>
+
+
+            <!-- Summaries -->
+            <h4>Sanity Check</h4>
+            <ul class="list-group">
+              <li class="list-group-item">
+                <span class="badge">0</span>
+                Total Categories
+              </li>
+              <li class="list-group-item">
+                <span class="badge">8</span>
+                Total Tags
+              </li>
+            </ul>
+
+          </div>
+        </div>
+        <div class="col-md-9" role="main">
+          <div class="row">
+            <div class="col-md-4">
+
+              <!-- Pages -->
+              <div class="docs-section">
+                <div class="docs-header" id="content">
+                  <h4>{{relative}} helper</h4>
+                  <strong>Page title: Foo</strong>
+                </div>
+                <ul class="nav nav-pills nav-stacked">
+                
+                  <li class="active">
+                    <a href="index.html">Foo</a>
+                  </li>
+                
+                  <li>
+                    <a href="../last-year/index.html">Last Year</a>
+                  </li>
+                
+                  <li>
+                    <a href="../new-year/index.html">New Year</a>
+                  </li>
+                
+                  <li>
+                    <a href="../bar/index.html">Bar</a>
+                  </li>
+                
+                </ul>
+              </div>
+              <hr>
+
+
+              <!-- Pages -->
+              <div class="docs-section">
+                <div class="docs-header" id="content">
+                  <h4>{{rel}} helper</h4>
+                  <strong>Page title: Foo</strong>
+                </div>
+                <ul class="nav nav-pills nav-stacked">
+                
+                  <li class="active">
+                    <a href="index.html">Foo</a>
+                  </li>
+                
+                  <li>
+                    <a href="../last-year/index.html">Last Year</a>
+                  </li>
+                
+                  <li>
+                    <a href="../new-year/index.html">New Year</a>
+                  </li>
+                
+                  <li>
+                    <a href="../bar/index.html">Bar</a>
+                  </li>
+                
+                </ul>
+              </div>
+            </div>
+            <div class="col-md-4">
+
+              <!-- Tags Collection -->
+              <div class="panel panel-default">
+                <div class="panel-heading">Tags</div>
+                <div class="panel-body">
+                
+                  <div>Related pages for: <span class="label label-warning">advanced</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../bar/index.html">Bar</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">android</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../bar/index.html">Bar</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">assemble</span></div>
+                  <ul>
+                  
+                    <li class="active">
+                      <a href="index.html">Foo</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../last-year/index.html">Last Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">beginner</span></div>
+                  <ul>
+                  
+                    <li class="active">
+                      <a href="index.html">Foo</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../last-year/index.html">Last Year</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../new-year/index.html">New Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">intro</span></div>
+                  <ul>
+                  
+                    <li class="active">
+                      <a href="index.html">Foo</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">javascript</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../last-year/index.html">Last Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">php</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../new-year/index.html">New Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">tutorial</span></div>
+                  <ul>
+                  
+                    <li class="active">
+                      <a href="index.html">Foo</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../last-year/index.html">Last Year</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../new-year/index.html">New Year</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../bar/index.html">Bar</a>
+                    </li>
+                  
+                  </ul>
+                
+                </div>
+              </div>
+            </div>
+            <div class="col-md-4">
+
+              <!-- Categories Collection -->
+              <div class="panel panel-default">
+                <div class="panel-heading">Categories</div>
+                <div class="panel-body">
+                
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Content -->
+          
+<h1 id="header">Header</h1>
+<blockquote>
+<p>Cras sit amet nibh libero, in gravida nulla.</p>
+</blockquote>
+
+
+          <hr>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/test/actual/filename_replacement_preset/last-year/index.html
+++ b/test/actual/filename_replacement_preset/last-year/index.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Last Year</title>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../../assets/validation.css">
+  </head>
+  <body>
+    <div class="container">
+      <section id="validate"></section>
+
+      <hr>
+      <!-- pagination -->
+      <h4>pagination</h4>
+      <ul class="pagination pagination-lg">
+
+  
+
+  
+    <li class="prev">
+      <a href="../foo/index.html">&laquo;</a>
+    </li>
+    <li class="prev">
+      <a href="../foo/index.html">&lsaquo;</a>
+    </li>
+  
+
+  
+    <li>
+      <a href="../foo/index.html">1</a>
+    </li>
+  
+    <li class="active">
+      <a href="index.html">2</a>
+    </li>
+  
+    <li>
+      <a href="../new-year/index.html">3</a>
+    </li>
+  
+    <li>
+      <a href="../bar/index.html">4</a>
+    </li>
+  
+
+  
+    <li class="next">
+      <a href="../new-year/index.html">&rsaquo;</a>
+    </li>
+    <li class="next">
+      <a href="../bar/index.html">&raquo;</a>
+    </li>
+  
+
+  
+
+</ul>
+      <hr>
+      <h4>pagination-justified</h4>
+      <ul class="pagination pagination-lg justified">
+
+  
+
+  
+    <li class="prev">
+      <a href="../foo/index.html">&laquo;</a>
+    </li>
+    <li class="prev">
+      <a href="../foo/index.html">&lsaquo;</a>
+    </li>
+  
+
+  
+    <li>
+      <a href="../foo/index.html">1</a>
+    </li>
+  
+    <li class="active">
+      <a href="index.html">2</a>
+    </li>
+  
+    <li>
+      <a href="../new-year/index.html">3</a>
+    </li>
+  
+    <li>
+      <a href="../bar/index.html">4</a>
+    </li>
+  
+
+  
+    <li class="next">
+      <a href="../new-year/index.html">&rsaquo;</a>
+    </li>
+    <li class="next">
+      <a href="../bar/index.html">&raquo;</a>
+    </li>
+  
+
+  
+
+</ul>
+      <hr>
+      <!-- paginate -->
+      <h4>paginate</h4>
+      <ul class="pager">
+
+  
+
+  
+    <li class="previous">
+      <a href="../foo/index.html">&larr; Prev</a>
+    </li>
+  
+
+  
+    <li>
+      <a href="../foo/index.html">1</a>
+    </li>
+  
+    <li class="active">
+      <a href="index.html">2</a>
+    </li>
+  
+    <li>
+      <a href="../new-year/index.html">3</a>
+    </li>
+  
+    <li>
+      <a href="../bar/index.html">4</a>
+    </li>
+  
+
+  
+    <li class="next">
+      <a href="../bar/index.html">Next &rarr;</a>
+    </li>
+  
+
+  
+
+</ul><style>
+.unselectable {
+  -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+}
+</style>
+      <hr>
+
+
+      <div class="row">
+        <div class="col-md-3">
+          <div class="bs-sidebar hidden-print" role="complementary">
+            <!-- navigation -->
+            <div class="list-group">
+  
+  <a href="../foo/index.html" class="list-group-item">
+    foo
+  </a>
+  
+  <a href="index.html" class="list-group-item active">
+    last-year
+  </a>
+  
+  <a href="../new-year/index.html" class="list-group-item">
+    new-year
+  </a>
+  
+  <a href="../bar/index.html" class="list-group-item">
+    bar
+  </a>
+  
+</div>
+            <hr>
+
+
+            <!-- pagination -->
+            <ul class="nav nav-pills nav-stacked">
+
+  
+
+  
+    <li class="prev">
+      <a href="../foo/index.html">First</a>
+    </li>
+    <li class="prev">
+      <a href="../foo/index.html">&larr; Previous</a>
+    </li>
+  
+
+  
+    <li>
+      <a href="../foo/index.html">1</a>
+    </li>
+  
+    <li class="active">
+      <a href="index.html">2</a>
+    </li>
+  
+    <li>
+      <a href="../new-year/index.html">3</a>
+    </li>
+  
+    <li>
+      <a href="../bar/index.html">4</a>
+    </li>
+  
+
+  
+    <li class="next">
+      <a href="../new-year/index.html">Next &rarr;</a>
+    </li>
+    <li class="next">
+      <a href="../bar/index.html">Last</a>
+    </li>
+  
+
+  
+
+</ul>
+            <hr>
+
+
+            <!-- Summaries -->
+            <h4>Sanity Check</h4>
+            <ul class="list-group">
+              <li class="list-group-item">
+                <span class="badge">0</span>
+                Total Categories
+              </li>
+              <li class="list-group-item">
+                <span class="badge">8</span>
+                Total Tags
+              </li>
+            </ul>
+
+          </div>
+        </div>
+        <div class="col-md-9" role="main">
+          <div class="row">
+            <div class="col-md-4">
+
+              <!-- Pages -->
+              <div class="docs-section">
+                <div class="docs-header" id="content">
+                  <h4>{{relative}} helper</h4>
+                  <strong>Page title: Last Year</strong>
+                </div>
+                <ul class="nav nav-pills nav-stacked">
+                
+                  <li>
+                    <a href="../foo/index.html">Foo</a>
+                  </li>
+                
+                  <li class="active">
+                    <a href="index.html">Last Year</a>
+                  </li>
+                
+                  <li>
+                    <a href="../new-year/index.html">New Year</a>
+                  </li>
+                
+                  <li>
+                    <a href="../bar/index.html">Bar</a>
+                  </li>
+                
+                </ul>
+              </div>
+              <hr>
+
+
+              <!-- Pages -->
+              <div class="docs-section">
+                <div class="docs-header" id="content">
+                  <h4>{{rel}} helper</h4>
+                  <strong>Page title: Last Year</strong>
+                </div>
+                <ul class="nav nav-pills nav-stacked">
+                
+                  <li>
+                    <a href="../foo/index.html">Foo</a>
+                  </li>
+                
+                  <li class="active">
+                    <a href="index.html">Last Year</a>
+                  </li>
+                
+                  <li>
+                    <a href="../new-year/index.html">New Year</a>
+                  </li>
+                
+                  <li>
+                    <a href="../bar/index.html">Bar</a>
+                  </li>
+                
+                </ul>
+              </div>
+            </div>
+            <div class="col-md-4">
+
+              <!-- Tags Collection -->
+              <div class="panel panel-default">
+                <div class="panel-heading">Tags</div>
+                <div class="panel-body">
+                
+                  <div>Related pages for: <span class="label label-warning">advanced</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../bar/index.html">Bar</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">android</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../bar/index.html">Bar</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">assemble</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../foo/index.html">Foo</a>
+                    </li>
+                  
+                    <li class="active">
+                      <a href="index.html">Last Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">beginner</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../foo/index.html">Foo</a>
+                    </li>
+                  
+                    <li class="active">
+                      <a href="index.html">Last Year</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../new-year/index.html">New Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">intro</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../foo/index.html">Foo</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">javascript</span></div>
+                  <ul>
+                  
+                    <li class="active">
+                      <a href="index.html">Last Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">php</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../new-year/index.html">New Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">tutorial</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../foo/index.html">Foo</a>
+                    </li>
+                  
+                    <li class="active">
+                      <a href="index.html">Last Year</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../new-year/index.html">New Year</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../bar/index.html">Bar</a>
+                    </li>
+                  
+                  </ul>
+                
+                </div>
+              </div>
+            </div>
+            <div class="col-md-4">
+
+              <!-- Categories Collection -->
+              <div class="panel panel-default">
+                <div class="panel-heading">Categories</div>
+                <div class="panel-body">
+                
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Content -->
+          
+<h1 id="header">Header</h1>
+<blockquote>
+<p>Cras sit amet nibh libero, in gravida nulla.</p>
+</blockquote>
+
+
+          <hr>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/test/actual/filename_replacement_preset/new-year/index.html
+++ b/test/actual/filename_replacement_preset/new-year/index.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>New Year</title>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../../assets/validation.css">
+  </head>
+  <body>
+    <div class="container">
+      <section id="validate"></section>
+
+      <hr>
+      <!-- pagination -->
+      <h4>pagination</h4>
+      <ul class="pagination pagination-lg">
+
+  
+
+  
+    <li class="prev">
+      <a href="../foo/index.html">&laquo;</a>
+    </li>
+    <li class="prev">
+      <a href="../last-year/index.html">&lsaquo;</a>
+    </li>
+  
+
+  
+    <li>
+      <a href="../foo/index.html">1</a>
+    </li>
+  
+    <li>
+      <a href="../last-year/index.html">2</a>
+    </li>
+  
+    <li class="active">
+      <a href="index.html">3</a>
+    </li>
+  
+    <li>
+      <a href="../bar/index.html">4</a>
+    </li>
+  
+
+  
+    <li class="next">
+      <a href="../bar/index.html">&rsaquo;</a>
+    </li>
+    <li class="next">
+      <a href="../bar/index.html">&raquo;</a>
+    </li>
+  
+
+  
+
+</ul>
+      <hr>
+      <h4>pagination-justified</h4>
+      <ul class="pagination pagination-lg justified">
+
+  
+
+  
+    <li class="prev">
+      <a href="../foo/index.html">&laquo;</a>
+    </li>
+    <li class="prev">
+      <a href="../last-year/index.html">&lsaquo;</a>
+    </li>
+  
+
+  
+    <li>
+      <a href="../foo/index.html">1</a>
+    </li>
+  
+    <li>
+      <a href="../last-year/index.html">2</a>
+    </li>
+  
+    <li class="active">
+      <a href="index.html">3</a>
+    </li>
+  
+    <li>
+      <a href="../bar/index.html">4</a>
+    </li>
+  
+
+  
+    <li class="next">
+      <a href="../bar/index.html">&rsaquo;</a>
+    </li>
+    <li class="next">
+      <a href="../bar/index.html">&raquo;</a>
+    </li>
+  
+
+  
+
+</ul>
+      <hr>
+      <!-- paginate -->
+      <h4>paginate</h4>
+      <ul class="pager">
+
+  
+
+  
+    <li class="previous">
+      <a href="../foo/index.html">&larr; Prev</a>
+    </li>
+  
+
+  
+    <li>
+      <a href="../foo/index.html">1</a>
+    </li>
+  
+    <li>
+      <a href="../last-year/index.html">2</a>
+    </li>
+  
+    <li class="active">
+      <a href="index.html">3</a>
+    </li>
+  
+    <li>
+      <a href="../bar/index.html">4</a>
+    </li>
+  
+
+  
+    <li class="next">
+      <a href="../bar/index.html">Next &rarr;</a>
+    </li>
+  
+
+  
+
+</ul><style>
+.unselectable {
+  -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+}
+</style>
+      <hr>
+
+
+      <div class="row">
+        <div class="col-md-3">
+          <div class="bs-sidebar hidden-print" role="complementary">
+            <!-- navigation -->
+            <div class="list-group">
+  
+  <a href="../foo/index.html" class="list-group-item">
+    foo
+  </a>
+  
+  <a href="../last-year/index.html" class="list-group-item">
+    last-year
+  </a>
+  
+  <a href="index.html" class="list-group-item active">
+    new-year
+  </a>
+  
+  <a href="../bar/index.html" class="list-group-item">
+    bar
+  </a>
+  
+</div>
+            <hr>
+
+
+            <!-- pagination -->
+            <ul class="nav nav-pills nav-stacked">
+
+  
+
+  
+    <li class="prev">
+      <a href="../foo/index.html">First</a>
+    </li>
+    <li class="prev">
+      <a href="../last-year/index.html">&larr; Previous</a>
+    </li>
+  
+
+  
+    <li>
+      <a href="../foo/index.html">1</a>
+    </li>
+  
+    <li>
+      <a href="../last-year/index.html">2</a>
+    </li>
+  
+    <li class="active">
+      <a href="index.html">3</a>
+    </li>
+  
+    <li>
+      <a href="../bar/index.html">4</a>
+    </li>
+  
+
+  
+    <li class="next">
+      <a href="../bar/index.html">Next &rarr;</a>
+    </li>
+    <li class="next">
+      <a href="../bar/index.html">Last</a>
+    </li>
+  
+
+  
+
+</ul>
+            <hr>
+
+
+            <!-- Summaries -->
+            <h4>Sanity Check</h4>
+            <ul class="list-group">
+              <li class="list-group-item">
+                <span class="badge">0</span>
+                Total Categories
+              </li>
+              <li class="list-group-item">
+                <span class="badge">8</span>
+                Total Tags
+              </li>
+            </ul>
+
+          </div>
+        </div>
+        <div class="col-md-9" role="main">
+          <div class="row">
+            <div class="col-md-4">
+
+              <!-- Pages -->
+              <div class="docs-section">
+                <div class="docs-header" id="content">
+                  <h4>{{relative}} helper</h4>
+                  <strong>Page title: New Year</strong>
+                </div>
+                <ul class="nav nav-pills nav-stacked">
+                
+                  <li>
+                    <a href="../foo/index.html">Foo</a>
+                  </li>
+                
+                  <li>
+                    <a href="../last-year/index.html">Last Year</a>
+                  </li>
+                
+                  <li class="active">
+                    <a href="index.html">New Year</a>
+                  </li>
+                
+                  <li>
+                    <a href="../bar/index.html">Bar</a>
+                  </li>
+                
+                </ul>
+              </div>
+              <hr>
+
+
+              <!-- Pages -->
+              <div class="docs-section">
+                <div class="docs-header" id="content">
+                  <h4>{{rel}} helper</h4>
+                  <strong>Page title: New Year</strong>
+                </div>
+                <ul class="nav nav-pills nav-stacked">
+                
+                  <li>
+                    <a href="../foo/index.html">Foo</a>
+                  </li>
+                
+                  <li>
+                    <a href="../last-year/index.html">Last Year</a>
+                  </li>
+                
+                  <li class="active">
+                    <a href="index.html">New Year</a>
+                  </li>
+                
+                  <li>
+                    <a href="../bar/index.html">Bar</a>
+                  </li>
+                
+                </ul>
+              </div>
+            </div>
+            <div class="col-md-4">
+
+              <!-- Tags Collection -->
+              <div class="panel panel-default">
+                <div class="panel-heading">Tags</div>
+                <div class="panel-body">
+                
+                  <div>Related pages for: <span class="label label-warning">advanced</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../bar/index.html">Bar</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">android</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../bar/index.html">Bar</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">assemble</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../foo/index.html">Foo</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../last-year/index.html">Last Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">beginner</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../foo/index.html">Foo</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../last-year/index.html">Last Year</a>
+                    </li>
+                  
+                    <li class="active">
+                      <a href="index.html">New Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">intro</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../foo/index.html">Foo</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">javascript</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../last-year/index.html">Last Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">php</span></div>
+                  <ul>
+                  
+                    <li class="active">
+                      <a href="index.html">New Year</a>
+                    </li>
+                  
+                  </ul>
+                
+                  <div>Related pages for: <span class="label label-warning">tutorial</span></div>
+                  <ul>
+                  
+                    <li>
+                      <a href="../foo/index.html">Foo</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../last-year/index.html">Last Year</a>
+                    </li>
+                  
+                    <li class="active">
+                      <a href="index.html">New Year</a>
+                    </li>
+                  
+                    <li>
+                      <a href="../bar/index.html">Bar</a>
+                    </li>
+                  
+                  </ul>
+                
+                </div>
+              </div>
+            </div>
+            <div class="col-md-4">
+
+              <!-- Categories Collection -->
+              <div class="panel panel-default">
+                <div class="panel-heading">Categories</div>
+                <div class="panel-body">
+                
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Content -->
+          
+<h1 id="header">Header</h1>
+<blockquote>
+<p>Cras sit amet nibh libero, in gravida nulla.</p>
+</blockquote>
+
+
+          <hr>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/test/fixtures/blog.hbs
+++ b/test/fixtures/blog.hbs
@@ -1,0 +1,4 @@
+---
+layout: default.hbs
+---
+{{#markdown}}{{> body }}{{/markdown}}

--- a/test/fixtures/posts/2013-10-11-foo.md
+++ b/test/fixtures/posts/2013-10-11-foo.md
@@ -1,0 +1,10 @@
+---
+layout: blog.hbs
+title: Foo
+category : lessons
+tags : [intro, beginner, assemble, tutorial]
+---
+
+# Header
+
+> Cras sit amet nibh libero, in gravida nulla.

--- a/test/fixtures/posts/2013-12-31-last-year.md
+++ b/test/fixtures/posts/2013-12-31-last-year.md
@@ -1,0 +1,10 @@
+---
+layout: blog.hbs
+title: Last Year
+category : snippets
+tags : [javascript, beginner, assemble, tutorial]
+---
+
+# Header
+
+> Cras sit amet nibh libero, in gravida nulla.

--- a/test/fixtures/posts/2014-01-01-new-year.md
+++ b/test/fixtures/posts/2014-01-01-new-year.md
@@ -1,0 +1,10 @@
+---
+layout: blog.hbs
+title: New Year
+category : snippets
+tags : [php, beginner, tutorial]
+---
+
+# Header
+
+> Cras sit amet nibh libero, in gravida nulla.

--- a/test/fixtures/posts/2014-02-12-bar.md
+++ b/test/fixtures/posts/2014-02-12-bar.md
@@ -1,0 +1,10 @@
+---
+layout: blog.hbs
+title: Bar
+category : snippets
+tags : [android, advanced, tutorial]
+---
+
+# Header
+
+> Cras sit amet nibh libero, in gravida nulla.


### PR DESCRIPTION
Parse a filename structure like this: `2014-02-11-foo.{hbs,md}` and convert it to something like this: `dest/blog/2014/02/11/foo/index.html` (or depends on [`preset`](https://github.com/assemble/assemble-contrib-permalinks#preset))

**Update**

I'll attach commit to add filename replacement option with two test using `preset` and `structure`.

When this option `true`, the date will be stripped from filename and then modify `page.basename`
and `page.slug` to use replacement version.

And then date strip from filename added to `page.data.date` property if it not exist in yfm data.
