### PR TITLE
Make the ignoring of 'index' files an option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -220,6 +220,18 @@ module.exports = function(grunt) {
           {expand: true, cwd: 'test/fixtures/pages', src: ['**/*.hbs'], dest: 'test/actual/index_pages/', ext: '.html'}
         ]
       },
+      // Should add basename to index if told to
+      index_pages_override: {
+        options: {
+          permalinks: {
+            ignoreIndexFiles: false,
+            structure: ':basename/index:ext'
+          }
+        },
+        files: [
+          {expand: true, cwd: 'test/fixtures/pages', src: ['**/*.hbs'], dest: 'test/actual/index_pages/', ext: '.html'}
+        ]
+      },
       // Should properly calculate dest path for collections
       collections_pretty: {
         options: {

--- a/README.md
+++ b/README.md
@@ -325,7 +325,17 @@ options: {
 
 #### 'index' pages
 
-Note that permalink structures will be ignored for files with the basename `index`. See [Issue #20](https://github.com/assemble/permalinks/issues/20) for more info.
+Note that permalink structures will be ignored by default for files with the basename `index`. See [Issue #20](https://github.com/assemble/permalinks/issues/20) for more info.
+
+If you don't want to ignore `index` files, you can set the option `ignoreIndexFiles` to `false`:
+
+```js
+options: {
+  permalinks: {
+    ignoreIndexFiles: false
+  }
+}
+```
 
 
 ### preset

--- a/index.js
+++ b/index.js
@@ -46,6 +46,11 @@ module.exports = function (assemble) {
       // Slugify basenames by default.
       opts.slugify = true;
 
+      // Ignore files with a basename of 'index' by default
+      if (_.isUndefined(opts.ignoreIndexFiles)) {
+        opts.ignoreIndexFiles = true;
+      }
+
       // Get the permalink pattern to use from options.permalinks.structure.
       // If one isn't defined, don't change anything.
       var structure = opts.structure;

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = function (assemble) {
       if(_.isUndefined(opts.structure) && _.isEmpty(permalink)) {
         page.data.dest = page.dest = page.data.dest || page.dest;
       } else {
-        if (page.data.basename === 'index') {
+        if (opts.ignoreIndexFiles && page.data.basename === 'index') {
           page.data.dest = page.dest = page.data.dest || page.dest;
         } else {
           page.data.dest = page.dest = path.join(page.data.dirname, permalink).replace(/\\/g, '/');


### PR DESCRIPTION
Not sure if this is useful to anyone else, but… I made the ignoring of 'index' files (as described in #20) an option, `ignoreIndexFiles`. If it is set to false, the defined `structure` will be used to construct the permalink, even for files with a basename of `index`.
